### PR TITLE
Fix vignette and create_skeleton

### DIFF
--- a/R/simulation_skeleton.R
+++ b/R/simulation_skeleton.R
@@ -15,9 +15,10 @@
 
 create_skeleton <- function(filename, ...) {
 
-  from <- system.file("templates","simulation_skeleton.R", package = "SimHelpers")
-  to <- paste0(filename,".R")
+  from <- system.file("templates", "simulation_skeleton.R", package = "simhelpers")
+  to <- paste0(filename, ".R")
   copy <- file.copy(from, to, ...)
 
   return(utils::file.edit(to))
+
 }

--- a/vignettes/simulation_workflow.Rmd
+++ b/vignettes/simulation_workflow.Rmd
@@ -305,7 +305,7 @@ plan(multisession)
 
 Once the cluster is configured, we can just replace [`pmap()`](https://purrr.tidyverse.org/reference/map2.html) from `purrr` with [`future_pmap()`](https://davisvaughan.github.io/furrr/) to run the simulation in parallel. 
 
-```{r}
+```{r, eval = FALSE}
 library(future)
 library(furrr)
 
@@ -326,7 +326,7 @@ results %>%
 
 In the `simhelpers` package, we have a function `evaluate_by_row()` that implements the `furrr` workflow: 
 
-```{r}
+```{r, eval = FALSE}
 plan(multisession)
 evaluate_by_row(params, run_sim) %>%
   kable()


### PR DESCRIPTION
1. Prevent blocks from evaluating in the `simulation_workflow` vignette because they caused an error when building on windows.
2. Use the correct package name in `create_skeleton()`