### PR TITLE
Fix small typo in the relative MSE MCSE formula in the MCSE vignette

### DIFF
--- a/vignettes/MCSE.Rmd
+++ b/vignettes/MCSE.Rmd
@@ -165,7 +165,7 @@ rel_dat <- tibble(Criterion = c("Relative Bias","Relative MSE", "Relative RMSE")
               Definition = c("$\\text{E}(T) / \\theta$", "$\\text{E}\\left[(T - \\theta)^2\\right]/ \\theta^2$", "$\\sqrt{\\text{E}\\left[(T - \\theta)^2\\right]/ \\theta^2}$"),
               Estimate = c("$\\bar{T} / \\theta$", "$\\frac{(\\bar{T} - \\theta)^2 + S_T^2}{\\theta^2}$", "$\\sqrt{\\frac{(\\bar{T} - \\theta)^2 + S_T^2}{\\theta^2}}$"),
               MCSE = c("$\\sqrt{S_T^2 / (K\\theta^2)}$", 
-                       "$\\sqrt{\\frac{1}{K\\theta^2}\\left[S_T^4 (k_T - 1) + 4 S_T^3 g_T(\\bar{T} - \\theta) + 4 S_T^2 (\\bar{T} - \\theta)^2\\right]}$", "$\\sqrt{\\frac{K - 1}{K} \\sum_{j=1}^K \\left(rRMSE_{(j)} - rRMSE)^2\\right)}$"))
+                       "$\\sqrt{\\frac{1}{K\\theta^4}\\left[S_T^4 (k_T - 1) + 4 S_T^3 g_T(\\bar{T} - \\theta) + 4 S_T^2 (\\bar{T} - \\theta)^2\\right]}$", "$\\sqrt{\\frac{K - 1}{K} \\sum_{j=1}^K \\left(rRMSE_{(j)} - rRMSE)^2\\right)}$"))
 
 knitr::kable(rel_dat, escape = FALSE, caption = "Table 2. Relative Performance Criteria") %>%
   kable_styling(bootstrap_options = c("striped", "hover"))


### PR DESCRIPTION
Hi Megha and James,

I have been using this package a lot (thank you very much for it!) and came across what I believe is a small typo in the MCSE vignette. The code seems to compute the MCSE of the relative MSE correctly (`calc_relative()` divides the absolute-MSE MCSE by `true_param^2`), but the vignette's Table 2 shows the formula with $K\theta^2$ under the square root, where it should be $K\theta^4$.

Let me know!
